### PR TITLE
Enable automatic failover default to true

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -11,6 +11,4 @@ locals {
 
   tags                          = merge(local.common_tags, var.additional_tags)
   resource_name                 = format("%s-%s", var.environment, var.application)
-  elasticache_subnet_group_name = coalesce(var.elasticache_subnet_group_name, join("", aws_elasticache_subnet_group.default.*.name))
-
 }

--- a/main.tf
+++ b/main.tf
@@ -75,7 +75,7 @@ resource "aws_elasticache_replication_group" "default" {
   parameter_group_name          = join("", aws_elasticache_parameter_group.default.*.name)
   availability_zones            = var.availability_zones
   automatic_failover_enabled    = var.automatic_failover_enabled
-  subnet_group_name             = local.elasticache_subnet_group_name
+  subnet_group_name             = local.resource_name
   security_group_ids            = var.use_existing_security_groups ? var.existing_security_groups : [join("", aws_security_group.default.*.id)]
   maintenance_window            = var.maintenance_window
   notification_topic_arn        = var.notification_topic_arn

--- a/main.tf
+++ b/main.tf
@@ -151,7 +151,7 @@ resource "aws_route53_record" "redis" {
   zone_id = var.zone_id
   name    = var.redis_fqdn != "" ? var.redis_fqdn : "${var.application}-redis"
   type    = "CNAME"
-  ttl     = 500
+  ttl     = 300
   records = var.cluster_mode_enabled ? aws_elasticache_replication_group.default.*.configuration_endpoint_address : aws_elasticache_replication_group.default.*.primary_endpoint_address
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -67,7 +67,7 @@ resource "aws_elasticache_replication_group" "default" {
   count = var.enabled ? 1 : 0
 
   auth_token                    = var.transit_encryption_enabled ? var.auth_token : null
-  replication_group_id          = var.replication_group_id == "" ? local.resource_name : var.replication_group_id
+  replication_group_id          = local.resource_name
   replication_group_description = local.resource_name
   node_type                     = var.instance_type
   number_cache_clusters         = var.cluster_mode_enabled ? null : var.cluster_size

--- a/variables.tf
+++ b/variables.tf
@@ -153,7 +153,7 @@ variable "maintenance_window" {
 
 variable "cluster_size" {
   type        = number
-  default     = 1
+  default     = 2
   description = "Number of nodes in cluster. *Ignored when `cluster_mode_enabled` == `true`*"
 }
 
@@ -228,7 +228,7 @@ variable "apply_immediately" {
 
 variable "automatic_failover_enabled" {
   type        = bool
-  default     = false
+  default     = true
   description = "Automatic failover (Not available for T1/T2 instances)"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -228,7 +228,7 @@ variable "apply_immediately" {
 
 variable "automatic_failover_enabled" {
   type        = bool
-  default     = false
+  default     = true
   description = "Automatic failover (Not available for T1/T2 instances)"
 }
 
@@ -272,12 +272,6 @@ variable "auth_token" {
   type        = string
   description = "Auth token for password protecting redis, `transit_encryption_enabled` must be set to `true`. Password must be longer than 16 chars"
   default     = null
-}
-
-variable "replication_group_id" {
-  type        = string
-  description = "Replication group ID with the following constraints: \nA name must contain from 1 to 20 alphanumeric characters or hyphens. \n The first character must be a letter. \n A name cannot end with a hyphen or contain two consecutive hyphens."
-  default     = ""
 }
 
 variable "snapshot_window" {

--- a/variables.tf
+++ b/variables.tf
@@ -228,7 +228,7 @@ variable "apply_immediately" {
 
 variable "automatic_failover_enabled" {
   type        = bool
-  default     = true
+  default     = false
   description = "Automatic failover (Not available for T1/T2 instances)"
 }
 


### PR DESCRIPTION
## Description
Modified few things as per existing Redis tf 

## Terragrunt Plan


```bash
Terraform will perform the following actions:

  # aws_cloudwatch_metric_alarm.cpu_utilization_high will be created
  + resource "aws_cloudwatch_metric_alarm" "cpu_utilization_high" {
      + actions_enabled                       = true
      + alarm_actions                         = (known after apply)
      + alarm_name                            = "poc1-terraform-aws-elasticache-redis-foo-cpu-high"
      + arn                                   = (known after apply)
      + comparison_operator                   = "GreaterThanThreshold"
      + dimensions                            = {
          + "CacheClusterId" = "poc1-terraform-aws-elasticache-redis-foo"
        }
      + evaluate_low_sample_count_percentiles = (known after apply)
      + evaluation_periods                    = 1
      + id                                    = (known after apply)
      + insufficient_data_actions             = (known after apply)
      + metric_name                           = "CPUUtilization"
      + namespace                             = "AWS/ElastiCache"
      + ok_actions                            = (known after apply)
      + period                                = 300
      + statistic                             = "Average"
      + threshold                             = 80
      + treat_missing_data                    = "missing"
    }

  # aws_cloudwatch_metric_alarm.memory_utilization_high will be created
  + resource "aws_cloudwatch_metric_alarm" "memory_utilization_high" {
      + actions_enabled                       = true
      + alarm_actions                         = (known after apply)
      + alarm_name                            = "poc1-terraform-aws-elasticache-redis-foo-memory-high"
      + arn                                   = (known after apply)
      + comparison_operator                   = "GreaterThanThreshold"
      + dimensions                            = {
          + "CacheClusterId" = "poc1-terraform-aws-elasticache-redis-foo"
        }
      + evaluate_low_sample_count_percentiles = (known after apply)
      + evaluation_periods                    = 1
      + id                                    = (known after apply)
      + insufficient_data_actions             = (known after apply)
      + metric_name                           = "MemoryUtilization"
      + namespace                             = "AWS/ElastiCache"
      + ok_actions                            = (known after apply)
      + period                                = 300
      + statistic                             = "Average"
      + threshold                             = 80
      + treat_missing_data                    = "missing"
    }

  # aws_elasticache_parameter_group.default[0] will be created
  + resource "aws_elasticache_parameter_group" "default" {
      + description = "Managed by Terraform"
      + family      = "redis4.0"
      + id          = (known after apply)
      + name        = "poc1-terraform-aws-elasticache-redis-foo"
    }

  # aws_elasticache_replication_group.default[0] will be created
  + resource "aws_elasticache_replication_group" "default" {
      + apply_immediately              = true
      + at_rest_encryption_enabled     = true
      + auto_minor_version_upgrade     = true
      + automatic_failover_enabled     = true
      + configuration_endpoint_address = (known after apply)
      + engine                         = "redis"
      + engine_version                 = "4.0.10"
      + id                             = (known after apply)
      + maintenance_window             = "wed:03:00-wed:04:00"
      + member_clusters                = (known after apply)
      + node_type                      = "cache.t2.micro"
      + number_cache_clusters          = 2
      + parameter_group_name           = "poc1-terraform-aws-elasticache-redis-foo"
      + port                           = 6379
      + primary_endpoint_address       = (known after apply)
      + replication_group_description  = "poc1-terraform-aws-elasticache-redis-foo"
      + replication_group_id           = "poc1-terraform-aws-elasticache-redis-foo"
      + security_group_ids             = (known after apply)
      + security_group_names           = (known after apply)
      + snapshot_retention_limit       = 0
      + snapshot_window                = "06:30-07:30"
      + subnet_group_name              = "poc1-terraform-aws-elasticache-redis-foo"
      + tags                           = {
          + "Application" = "terraform-aws-elasticache-redis-foo"
          + "Environment" = "poc1"
          + "Name"        = "poc1-terraform-aws-elasticache-redis-foo"
          + "Owner"       = "devops@opploans.com"
          + "Repo"        = "terraform-aws-elasticache-redis"
          + "RepoPath"    = "test"
          + "Tool"        = "terraform"
        }
      + transit_encryption_enabled     = true

      + cluster_mode {
          + num_node_groups         = (known after apply)
          + replicas_per_node_group = (known after apply)
        }
    }

  # aws_elasticache_subnet_group.default[0] will be created
  + resource "aws_elasticache_subnet_group" "default" {
      + description = "Managed by Terraform"
      + id          = (known after apply)
      + name        = "poc1-terraform-aws-elasticache-redis-foo"
      + subnet_ids  = [
          + "subnet-07ca94f8c92792ebf",
        ]
    }

  # aws_route53_record.redis will be created
  + resource "aws_route53_record" "redis" {
      + allow_overwrite = (known after apply)
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = "terraform-aws-elasticache-redis-foo-redis"
      + records         = (known after apply)
      + ttl             = 300
      + type            = "CNAME"
      + zone_id         = "ZBQY0PPB9MV8M"
    }

  # aws_security_group.default[0] will be created
  + resource "aws_security_group" "default" {
      + arn                    = (known after apply)
      + description            = "Managed by Terraform"
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = "poc1-terraform-aws-elasticache-redis-foo"
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Application" = "terraform-aws-elasticache-redis-foo"
          + "Environment" = "poc1"
          + "Name"        = "poc1-terraform-aws-elasticache-redis-foo"
          + "Owner"       = "devops@opploans.com"
          + "Repo"        = "terraform-aws-elasticache-redis"
          + "RepoPath"    = "test"
          + "Tool"        = "terraform"
        }
      + vpc_id                 = "vpc-047f251367f6941dc"
    }

  # aws_security_group_rule.egress[0] will be created
  + resource "aws_security_group_rule" "egress" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "Allow all egress traffic"
      + from_port                = 0
      + id                       = (known after apply)
      + protocol                 = "-1"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 0
      + type                     = "egress"
    }

  # aws_sns_topic.cloudwatch will be created
  + resource "aws_sns_topic" "cloudwatch" {
      + arn          = (known after apply)
      + display_name = "poc1-terraform-aws-elasticache-redis-foo"
      + id           = (known after apply)
      + name         = "poc1-terraform-aws-elasticache-redis-foo"
      + policy       = (known after apply)
    }

  # aws_sns_topic_subscription.cloudwatch will be created
  + resource "aws_sns_topic_subscription" "cloudwatch" {
      + arn                             = (known after apply)
      + confirmation_timeout_in_minutes = 1
      + endpoint                        = "https://events.pagerduty.com/integration/36a0f8f84e6640289c1da0031dc352dc/enqueue"
      + endpoint_auto_confirms          = true
      + id                              = (known after apply)
      + protocol                        = "https"
      + raw_message_delivery            = false
      + topic_arn                       = (known after apply)
    }

Plan: 10 to add, 0 to change, 0 to destroy.

```

</details>
