### PR TITLE
Add unique resource name

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@
 |------|-------------|------|---------|:-----:|
 | additional\_tags | Additional tags to add to your resources in addition to default. | `map(string)` | `{}` | no |
 | alarm\_actions | Alarm action list | `list(string)` | `[]` | no |
-| alarm\_cpu\_threshold\_percent | CPU threshold alarm level | `number` | `75` | no |
-| alarm\_memory\_threshold\_bytes | Ram threshold alarm level | `number` | `10000000` | no |
 | allowed\_cidr\_blocks | List of CIDR blocks that are allowed ingress to the cluster's Security Group created in the module | `list(string)` | `[]` | no |
 | allowed\_security\_groups | List of Security Group IDs that are allowed ingress to the cluster's Security Group created in the module | `list(string)` | `[]` | no |
 | application | This value is part of the AWS cloud asset tagging strategy to be able to group items by application. | `string` | n/a | yes |
@@ -22,14 +20,14 @@
 | at\_rest\_encryption\_enabled | Enable encryption at rest | `bool` | `true` | no |
 | attributes | Additional attributes (\_e.g._ "1") | `list(string)` | `[]` | no |
 | auth\_token | Auth token for password protecting redis, `transit_encryption_enabled` must be set to `true`. Password must be longer than 16 chars | `string` | n/a | yes |
-| automatic\_failover\_enabled | Automatic failover (Not available for T1/T2 instances) | `bool` | `false` | no |
+| automatic\_failover\_enabled | Automatic failover (Not available for T1/T2 instances) | `bool` | `true` | no |
 | availability\_zones | Availability zone IDs | `list(string)` | `[]` | no |
 | aws\_profile | AWS profile for provider | `string` | `"default"` | no |
 | aws\_region | AWS region for provider. | `string` | `"us-east-1"` | no |
 | cluster\_mode\_enabled | Flag to enable/disable creation of a native redis cluster. `automatic_failover_enabled` must be set to `true`. Only 1 `cluster_mode` block is allowed | `bool` | `false` | no |
 | cluster\_mode\_num\_node\_groups | Number of node groups (shards) for this Redis replication group. Changing this number will trigger an online resizing operation before other settings modifications | `number` | `0` | no |
 | cluster\_mode\_replicas\_per\_node\_group | Number of replica nodes in each node group. Valid values are 0 to 5. Changing this number will force a new resource | `number` | `0` | no |
-| cluster\_size | Number of nodes in cluster. *Ignored when `cluster_mode_enabled` == `true`\* | `number` | `1` | no |
+| cluster\_size | Number of nodes in cluster. *Ignored when `cluster_mode_enabled` == `true`\* | `number` | `2` | no |
 | cpu\_utilization\_high\_evaluation\_periods | Number of periods to evaluate for the alarm. | `number` | `1` | no |
 | cpu\_utilization\_high\_period | Duration in seconds to evaluate for the alarm. | `number` | `300` | no |
 | cpu\_utilization\_high\_threshold | The maximum percentage of CPU utilization average. | `number` | `80` | no |
@@ -52,7 +50,6 @@
 | parameter | A list of Redis parameters to apply. Note that parameters may differ from one Redis family to another | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
 | port | Redis port | `number` | `6379` | no |
 | redis\_fqdn | The subdomain to use for the CNAME record. If not provided then the CNAME record will use var.name. | `string` | `""` | no |
-| replication\_group\_id | Replication group ID with the following constraints: <br>A name must contain from 1 to 20 alphanumeric characters or hyphens.   The first character must be a letter.   A name cannot end with a hyphen or contain two consecutive hyphens. | `string` | `""` | no |
 | repo | This value is part of the AWS cloud asset tagging strategy to be able to group items by repo. | `string` | n/a | yes |
 | repo\_path | This value is part of the AWS cloud asset tagging strategy to be able to group items by repo and subgroup them by the repos path. | `string` | n/a | yes |
 | snapshot\_retention\_limit | The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them. | `number` | `0` | no |

--- a/locals.tf
+++ b/locals.tf
@@ -1,3 +1,10 @@
+module "unique_name" {
+  source = "git@github.com:opploans/terraform-opploans-unique-resource-name?ref=v0.2.0"
+
+  environment = var.environment
+  application = var.application
+}
+
 locals {
   common_tags = {
     Name        = local.resource_name
@@ -10,5 +17,6 @@ locals {
   }
 
   tags                          = merge(local.common_tags, var.additional_tags)
-  resource_name                 = format("%s-%s", var.environment, var.application)
+  resource_name        = module.unique_name.resource_name
+unique_resource_name = module.unique_name.unique_resource_name
 }

--- a/locals.tf
+++ b/locals.tf
@@ -16,7 +16,7 @@ locals {
     Tool        = "terraform"
   }
 
-  tags                          = merge(local.common_tags, var.additional_tags)
+  tags                 = merge(local.common_tags, var.additional_tags)
   resource_name        = module.unique_name.resource_name
-unique_resource_name = module.unique_name.unique_resource_name
+  unique_resource_name = module.unique_name.unique_resource_name
 }

--- a/main.tf
+++ b/main.tf
@@ -75,7 +75,7 @@ resource "aws_elasticache_replication_group" "default" {
   parameter_group_name          = join("", aws_elasticache_parameter_group.default.*.name)
   availability_zones            = var.availability_zones
   automatic_failover_enabled    = var.automatic_failover_enabled
-  subnet_group_name             = local.unique_resource_name
+  subnet_group_name             = local.resource_name
   security_group_ids            = var.use_existing_security_groups ? var.existing_security_groups : [join("", aws_security_group.default.*.id)]
   maintenance_window            = var.maintenance_window
   notification_topic_arn        = var.notification_topic_arn

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@
 resource "aws_security_group" "default" {
   count  = var.enabled && var.use_existing_security_groups == false ? 1 : 0
   vpc_id = var.vpc_id
-  name   = local.resource_name
+  name   = local.unique_resource_name
   tags   = local.tags
 }
 
@@ -49,7 +49,7 @@ resource "aws_elasticache_subnet_group" "default" {
 
 resource "aws_elasticache_parameter_group" "default" {
   count  = var.enabled ? 1 : 0
-  name   = local.resource_name
+  name   = local.unique_resource_name
   family = var.family
 
 
@@ -67,15 +67,15 @@ resource "aws_elasticache_replication_group" "default" {
   count = var.enabled ? 1 : 0
 
   auth_token                    = var.transit_encryption_enabled ? var.auth_token : null
-  replication_group_id          = local.resource_name
-  replication_group_description = local.resource_name
+  replication_group_id          = local.unique_resource_name
+  replication_group_description = local.unique_resource_name
   node_type                     = var.instance_type
   number_cache_clusters         = var.cluster_mode_enabled ? null : var.cluster_size
   port                          = var.port
   parameter_group_name          = join("", aws_elasticache_parameter_group.default.*.name)
   availability_zones            = var.availability_zones
   automatic_failover_enabled    = var.automatic_failover_enabled
-  subnet_group_name             = local.resource_name
+  subnet_group_name             = local.unique_resource_name
   security_group_ids            = var.use_existing_security_groups ? var.existing_security_groups : [join("", aws_security_group.default.*.id)]
   maintenance_window            = var.maintenance_window
   notification_topic_arn        = var.notification_topic_arn
@@ -99,7 +99,7 @@ resource "aws_elasticache_replication_group" "default" {
 }
 
 resource "aws_sns_topic" "cloudwatch" {
-  name         = local.resource_name
+  name         = local.unique_resource_name
   display_name = local.resource_name
 }
 
@@ -112,7 +112,7 @@ resource "aws_sns_topic_subscription" "cloudwatch" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu_utilization_high" {
-  alarm_name                = format("%s-%s", local.resource_name, "cpu-high")
+  alarm_name                = format("%s-%s", local.unique_resource_name, "cpu-high")
   comparison_operator       = "GreaterThanThreshold"
   evaluation_periods        = var.cpu_utilization_high_evaluation_periods
   metric_name               = "CPUUtilization"
@@ -130,7 +130,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_high" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "memory_utilization_high" {
-  alarm_name                = format("%s-%s", local.resource_name, "memory-high")
+  alarm_name                = format("%s-%s", local.unique_resource_name, "memory-high")
   comparison_operator       = "GreaterThanThreshold"
   evaluation_periods        = var.memory_utilization_high_evaluation_periods
   metric_name               = "MemoryUtilization"

--- a/variables.tf
+++ b/variables.tf
@@ -207,7 +207,7 @@ variable "notification_topic_arn" {
   default     = ""
   description = "Notification topic arn"
 }
-        
+
 variable "alarm_actions" {
   type        = list(string)
   description = "Alarm action list"


### PR DESCRIPTION
Terragrunt plan output:
```bash

Terraform will perform the following actions:

  # aws_cloudwatch_metric_alarm.cpu_utilization_high will be created
  + resource "aws_cloudwatch_metric_alarm" "cpu_utilization_high" {
      + actions_enabled                       = true
      + alarm_actions                         = (known after apply)
      + alarm_name                            = (known after apply)
      + arn                                   = (known after apply)
      + comparison_operator                   = "GreaterThanThreshold"
      + dimensions                            = {
          + "CacheClusterId" = "poc1-terraform-aws-elasticache-redis-foo"
        }
      + evaluate_low_sample_count_percentiles = (known after apply)
      + evaluation_periods                    = 1
      + id                                    = (known after apply)
      + insufficient_data_actions             = (known after apply)
      + metric_name                           = "CPUUtilization"
      + namespace                             = "AWS/ElastiCache"
      + ok_actions                            = (known after apply)
      + period                                = 300
      + statistic                             = "Average"
      + threshold                             = 80
      + treat_missing_data                    = "missing"
    }

  # aws_cloudwatch_metric_alarm.memory_utilization_high will be created
  + resource "aws_cloudwatch_metric_alarm" "memory_utilization_high" {
      + actions_enabled                       = true
      + alarm_actions                         = (known after apply)
      + alarm_name                            = (known after apply)
      + arn                                   = (known after apply)
      + comparison_operator                   = "GreaterThanThreshold"
      + dimensions                            = {
          + "CacheClusterId" = "poc1-terraform-aws-elasticache-redis-foo"
        }
      + evaluate_low_sample_count_percentiles = (known after apply)
      + evaluation_periods                    = 1
      + id                                    = (known after apply)
      + insufficient_data_actions             = (known after apply)
      + metric_name                           = "MemoryUtilization"
      + namespace                             = "AWS/ElastiCache"
      + ok_actions                            = (known after apply)
      + period                                = 300
      + statistic                             = "Average"
      + threshold                             = 80
      + treat_missing_data                    = "missing"
    }

  # aws_elasticache_parameter_group.default[0] will be created
  + resource "aws_elasticache_parameter_group" "default" {
      + description = "Managed by Terraform"
      + family      = "redis4.0"
      + id          = (known after apply)
      + name        = (known after apply)
    }

  # aws_elasticache_replication_group.default[0] will be created
  + resource "aws_elasticache_replication_group" "default" {
      + apply_immediately              = true
      + at_rest_encryption_enabled     = true
      + auto_minor_version_upgrade     = true
      + automatic_failover_enabled     = true
      + configuration_endpoint_address = (known after apply)
      + engine                         = "redis"
      + engine_version                 = "4.0.10"
      + id                             = (known after apply)
      + maintenance_window             = "wed:03:00-wed:04:00"
      + member_clusters                = (known after apply)
      + node_type                      = "cache.t2.micro"
      + number_cache_clusters          = 2
      + parameter_group_name           = (known after apply)
      + port                           = 6379
      + primary_endpoint_address       = (known after apply)
      + replication_group_description  = (known after apply)
      + replication_group_id           = (known after apply)
      + security_group_ids             = (known after apply)
      + security_group_names           = (known after apply)
      + snapshot_retention_limit       = 0
      + snapshot_window                = "06:30-07:30"
      + subnet_group_name              = "poc1-terraform-aws-elasticache-redis-foo"
      + tags                           = {
          + "Application" = "terraform-aws-elasticache-redis-foo"
          + "Environment" = "poc1"
          + "Name"        = "poc1-terraform-aws-elasticache-redis-foo"
          + "Owner"       = "devops@opploans.com"
          + "Repo"        = "terraform-aws-elasticache-redis"
          + "RepoPath"    = "test"
          + "Tool"        = "terraform"
        }
      + transit_encryption_enabled     = true

      + cluster_mode {
          + num_node_groups         = (known after apply)
          + replicas_per_node_group = (known after apply)
        }
    }

  # aws_elasticache_subnet_group.default[0] will be created
  + resource "aws_elasticache_subnet_group" "default" {
      + description = "Managed by Terraform"
      + id          = (known after apply)
      + name        = "poc1-terraform-aws-elasticache-redis-foo"
      + subnet_ids  = [
          + "subnet-07ca94f8c92792ebf",
        ]
    }

  # aws_route53_record.redis will be created
  + resource "aws_route53_record" "redis" {
      + allow_overwrite = (known after apply)
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = "terraform-aws-elasticache-redis-foo-redis"
      + records         = (known after apply)
      + ttl             = 300
      + type            = "CNAME"
      + zone_id         = "ZBQY0PPB9MV8M"
    }

  # aws_security_group.default[0] will be created
  + resource "aws_security_group" "default" {
      + arn                    = (known after apply)
      + description            = "Managed by Terraform"
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = (known after apply)
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Application" = "terraform-aws-elasticache-redis-foo"
          + "Environment" = "poc1"
          + "Name"        = "poc1-terraform-aws-elasticache-redis-foo"
          + "Owner"       = "devops@opploans.com"
          + "Repo"        = "terraform-aws-elasticache-redis"
          + "RepoPath"    = "test"
          + "Tool"        = "terraform"
        }
      + vpc_id                 = "vpc-047f251367f6941dc"
    }

  # aws_security_group_rule.egress[0] will be created
  + resource "aws_security_group_rule" "egress" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "Allow all egress traffic"
      + from_port                = 0
      + id                       = (known after apply)
      + protocol                 = "-1"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 0
      + type                     = "egress"
    }

  # aws_sns_topic.cloudwatch will be created
  + resource "aws_sns_topic" "cloudwatch" {
      + arn          = (known after apply)
      + display_name = "poc1-terraform-aws-elasticache-redis-foo"
      + id           = (known after apply)
      + name         = (known after apply)
      + policy       = (known after apply)
    }

  # aws_sns_topic_subscription.cloudwatch will be created
  + resource "aws_sns_topic_subscription" "cloudwatch" {
      + arn                             = (known after apply)
      + confirmation_timeout_in_minutes = 1
      + endpoint                        = "https://events.pagerduty.com/integration/36a0f8f84e6640289c1da0031dc352dc/enqueue"
      + endpoint_auto_confirms          = true
      + id                              = (known after apply)
      + protocol                        = "https"
      + raw_message_delivery            = false
      + topic_arn                       = (known after apply)
    }

  # module.unique_name.random_id.r will be created
  + resource "random_id" "r" {
      + b64         = (known after apply)
      + b64_std     = (known after apply)
      + b64_url     = (known after apply)
      + byte_length = 2
      + dec         = (known after apply)
      + hex         = (known after apply)
      + id          = (known after apply)
      + prefix      = "poc1-terraform-aws-elastica-"
    }

Plan: 11 to add, 0 to change, 0 to destroy.
```
