### PR TITLE
added workaround for multi az to be enabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -59,13 +59,14 @@ resource "aws_elasticache_replication_group" "default" {
       REPLICATION_GROUP_ID = aws_elasticache_replication_group.default.replication_group_id
     }
     command = <<-EOT
-              aws elasticache modify-replication-group \
-                --replication-group-id $REPLICATION_GROUP_ID \
-                --multi-az-enabled \
-                --apply-immediately \
-                --region us-east-1
-    EOT
-  }
+                  AWS_PROFILE=var.aws_profile \
+                  aws elasticache modify-replication-group \
+                  --replication-group-id $REPLICATION_GROUP_ID \
+                  --multi-az-enabled \
+                  --apply-immediately \
+                  --region var.aws_region
+        EOT
+    }
 
   dynamic "cluster_mode" {
     for_each = var.cluster_mode_enabled ? ["true"] : []

--- a/main.tf
+++ b/main.tf
@@ -58,6 +58,7 @@ resource "aws_elasticache_replication_group" "default" {
     environment = {
       REPLICATION_GROUP_ID = aws_elasticache_replication_group.default.replication_group_id
       AWS_PROFILE = var.aws_profile
+      region = var.aws_region
     }
     command = <<-EOT
       AWS_PROFILE=$AWS_PROFILE \
@@ -65,7 +66,7 @@ resource "aws_elasticache_replication_group" "default" {
         --replication-group-id $REPLICATION_GROUP_ID \
         --multi-az-enabled \
         --apply-immediately \
-        --region var.aws_region
+        --region $region
     EOT
     }
 

--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ resource "aws_elasticache_replication_group" "default" {
     environment = {
       REPLICATION_GROUP_ID = aws_elasticache_replication_group.default.replication_group_id
       AWS_PROFILE = var.aws_profile
-      region = var.aws_region
+      AWS_REGION = var.aws_region
     }
     command = <<-EOT
       AWS_PROFILE=$AWS_PROFILE \
@@ -66,7 +66,7 @@ resource "aws_elasticache_replication_group" "default" {
         --replication-group-id $REPLICATION_GROUP_ID \
         --multi-az-enabled \
         --apply-immediately \
-        --region $region
+        --region $AWS_REGION
     EOT
     }
 

--- a/main.tf
+++ b/main.tf
@@ -54,6 +54,18 @@ resource "aws_elasticache_replication_group" "default" {
   apply_immediately             = var.apply_immediately
 
   tags = local.tags
+  provisioner "local-exec" {
+    environment = {
+      REPLICATION_GROUP_ID = aws_elasticache_replication_group.default.replication_group_id
+    }
+    command = <<-EOT
+              aws elasticache modify-replication-group \
+                --replication-group-id $REPLICATION_GROUP_ID \
+                --multi-az-enabled \
+                --apply-immediately \
+                --region us-east-1
+    EOT
+  }
 
   dynamic "cluster_mode" {
     for_each = var.cluster_mode_enabled ? ["true"] : []

--- a/main.tf
+++ b/main.tf
@@ -57,15 +57,16 @@ resource "aws_elasticache_replication_group" "default" {
   provisioner "local-exec" {
     environment = {
       REPLICATION_GROUP_ID = aws_elasticache_replication_group.default.replication_group_id
+      AWS_PROFILE = var.aws_profile
     }
     command = <<-EOT
-                  AWS_PROFILE=var.aws_profile \
-                  aws elasticache modify-replication-group \
-                  --replication-group-id $REPLICATION_GROUP_ID \
-                  --multi-az-enabled \
-                  --apply-immediately \
-                  --region var.aws_region
-        EOT
+      AWS_PROFILE=$AWS_PROFILE \
+      aws elasticache modify-replication-group \
+        --replication-group-id $REPLICATION_GROUP_ID \
+        --multi-az-enabled \
+        --apply-immediately \
+        --region var.aws_region
+    EOT
     }
 
   dynamic "cluster_mode" {

--- a/test/terragrunt.hcl
+++ b/test/terragrunt.hcl
@@ -43,4 +43,5 @@ inputs = {
   vpc_id                          = "vpc-047f251367f6941dc"
   zone_id                         = "ZBQY0PPB9MV8M"
   subnet_ids                      = ["subnet-07ca94f8c92792ebf"]
+  auth_token                      = "test123456789-123456"
 }


### PR DESCRIPTION
Terragrunt plan output:
````bash
 
  # aws_cloudwatch_metric_alarm.cpu_utilization_high will be created
  + resource "aws_cloudwatch_metric_alarm" "cpu_utilization_high" {
      + actions_enabled                       = true
      + alarm_actions                         = (known after apply)
      + alarm_name                            = "poc1-terraform-aws-elasticache-redis-foo-cpu-high"
      + arn                                   = (known after apply)
      + comparison_operator                   = "GreaterThanThreshold"
      + dimensions                            = {
          + "CacheClusterId" = "poc1-terraform-aws-elasticache-redis-foo"
        }
      + evaluate_low_sample_count_percentiles = (known after apply)
      + evaluation_periods                    = 1
      + id                                    = (known after apply)
      + insufficient_data_actions             = (known after apply)
      + metric_name                           = "CPUUtilization"
      + namespace                             = "AWS/ElastiCache"
      + ok_actions                            = (known after apply)
      + period                                = 300
      + statistic                             = "Average"
      + threshold                             = 80
      + treat_missing_data                    = "missing"
    }

  # aws_cloudwatch_metric_alarm.memory_utilization_high will be created
  + resource "aws_cloudwatch_metric_alarm" "memory_utilization_high" {
      + actions_enabled                       = true
      + alarm_actions                         = (known after apply)
      + alarm_name                            = "poc1-terraform-aws-elasticache-redis-foo-memory-high"
      + arn                                   = (known after apply)
      + comparison_operator                   = "GreaterThanThreshold"
      + dimensions                            = {
          + "CacheClusterId" = "poc1-terraform-aws-elasticache-redis-foo"
        }
      + evaluate_low_sample_count_percentiles = (known after apply)
      + evaluation_periods                    = 1
      + id                                    = (known after apply)
      + insufficient_data_actions             = (known after apply)
      + metric_name                           = "MemoryUtilization"
      + namespace                             = "AWS/ElastiCache"
      + ok_actions                            = (known after apply)
      + period                                = 300
      + statistic                             = "Average"
      + threshold                             = 80
      + treat_missing_data                    = "missing"
    }

  # aws_elasticache_parameter_group.default will be created
  + resource "aws_elasticache_parameter_group" "default" {
      + description = "Managed by Terraform"
      + family      = "redis4.0"
      + id          = (known after apply)
      + name        = "poc1-terraform-aws-elasticache-redis-foo"

      + parameter {
          + name  = "cluster-enabled"
          + value = "yes"
        }
    }

  # aws_elasticache_replication_group.default will be created
  + resource "aws_elasticache_replication_group" "default" {
      + apply_immediately              = true
      + at_rest_encryption_enabled     = true
      + auth_token                     = (sensitive value)
      + auto_minor_version_upgrade     = true
      + automatic_failover_enabled     = true
      + configuration_endpoint_address = (known after apply)
      + engine                         = "redis"
      + engine_version                 = "4.0.10"
      + id                             = (known after apply)
      + maintenance_window             = "wed:03:00-wed:04:00"
      + member_clusters                = (known after apply)
      + node_type                      = "cache.t2.micro"
      + number_cache_clusters          = (known after apply)
      + parameter_group_name           = "poc1-terraform-aws-elasticache-redis-foo"
      + port                           = 6379
      + primary_endpoint_address       = (known after apply)
      + replication_group_description  = "poc1-terraform-aws-elasticache-redis-foo"
      + replication_group_id           = "poc1-terraform-aws-elasticache-redis-foo"
      + security_group_ids             = (known after apply)
      + security_group_names           = (known after apply)
      + snapshot_retention_limit       = 0
      + snapshot_window                = "06:30-07:30"
      + subnet_group_name              = "poc1-terraform-aws-elasticache-redis-foo"
      + tags                           = {
          + "Application" = "terraform-aws-elasticache-redis-foo"
          + "Environment" = "poc1"
          + "Name"        = "poc1-terraform-aws-elasticache-redis-foo"
          + "Owner"       = "devops@opploans.com"
          + "Repo"        = "terraform-aws-elasticache-redis"
          + "RepoPath"    = "test"
          + "Tool"        = "terraform"
        }
      + transit_encryption_enabled     = true

      + cluster_mode {
          + num_node_groups         = 2
          + replicas_per_node_group = 1
        }
    }

  # aws_elasticache_subnet_group.default will be created
  + resource "aws_elasticache_subnet_group" "default" {
      + description = "Managed by Terraform"
      + id          = (known after apply)
      + name        = "poc1-terraform-aws-elasticache-redis-foo"
      + subnet_ids  = [
          + "subnet-017d34f116279feaf",
          + "subnet-0ee1c4e350774f506",
        ]
    }

  # aws_route53_record.redis will be created
  + resource "aws_route53_record" "redis" {
      + allow_overwrite = (known after apply)
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = "terraform-aws-elasticache-redis-foo-redis"
      + records         = (known after apply)
      + ttl             = 300
      + type            = "CNAME"
      + zone_id         = "ZBQY0PPB9MV8M"
    }

  # aws_sns_topic.cloudwatch will be created
  + resource "aws_sns_topic" "cloudwatch" {
      + arn          = (known after apply)
      + display_name = "poc1-terraform-aws-elasticache-redis-foo"
      + id           = (known after apply)
      + name         = "poc1-terraform-aws-elasticache-redis-foo"
      + policy       = (known after apply)
    }

  # aws_sns_topic_subscription.cloudwatch will be created
  + resource "aws_sns_topic_subscription" "cloudwatch" {
      + arn                             = (known after apply)
      + confirmation_timeout_in_minutes = 1
      + endpoint                        = "https://events.pagerduty.com/integration/36a0f8f84e6640289c1da0031dc352dc/enqueue"
      + endpoint_auto_confirms          = true
      + id                              = (known after apply)
      + protocol                        = "https"
      + raw_message_delivery            = false
      + topic_arn                       = (known after apply)
    }

  # module.redis_security_group.aws_security_group.main will be created
  + resource "aws_security_group" "main" {
      + arn                    = (known after apply)
      + description            = "Managed by Terraform"
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = (known after apply)
      + name_prefix            = "poc1-terraform-aws-elasticache-redis-foo-redis-"
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Application" = "terraform-aws-elasticache-redis-foo"
          + "Environment" = "poc1"
          + "Name"        = "poc1-terraform-aws-elasticache-redis-foo-redis"
          + "Owner"       = "devops@opploans.com"
          + "Repo"        = "terraform-aws-elasticache-redis"
          + "RepoPath"    = "test"
          + "Tool"        = "terraform"
        }
      + vpc_id                 = "vpc-047f251367f6941dc"
    }

  # module.redis_security_group.aws_security_group_rule.ingress["TCP/6379 from internal OppLoans CIDRs"] will be created
  + resource "aws_security_group_rule" "ingress" {
      + cidr_blocks              = [
          + "10.10.0.0/22",
          + "192.168.10.0/24",
          + "10.124.0.0/18",
          + "10.124.64.0/18",
          + "172.18.156.203/32",
        ]
      + description              = "TCP/6379 from internal OppLoans CIDRs"
      + from_port                = 6379
      + id                       = (known after apply)
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 6379
      + type                     = "ingress"
    }

  # module.redis_security_group.aws_security_group_rule.ingress["TCP/6379 from private subnets"] will be created
  + resource "aws_security_group_rule" "ingress" {
      + cidr_blocks              = [
          + "172.28.0.0/22",
          + "172.28.4.0/22",
        ]
      + description              = "TCP/6379 from private subnets"
      + from_port                = 6379
      + id                       = (known after apply)
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 6379
      + type                     = "ingress"
    }

  # module.unique_name.random_id.r will be created
  + resource "random_id" "r" {
      + b64         = (known after apply)
      + b64_std     = (known after apply)
      + b64_url     = (known after apply)
      + byte_length = 2
      + dec         = (known after apply)
      + hex         = (known after apply)
      + id          = (known after apply)
      + prefix      = "poc1-terraform-aws-elastica-"
    }

Plan: 12 to add, 0 to change, 0 to destroy.


```